### PR TITLE
Fix trivy entrypoint command

### DIFF
--- a/src/trivyHelper.ts
+++ b/src/trivyHelper.ts
@@ -14,7 +14,7 @@ import * as allowedlistHandler from './allowedlistHandler';
 
 export const TRIVY_EXIT_CODE = 5;
 export const trivyToolName = "trivy";
-const stableTrivyVersion = "0.5.2";
+const stableTrivyVersion = "0.22.0";
 const trivyLatestReleaseUrl = "https://api.github.com/repos/aquasecurity/trivy/releases/latest";
 const KEY_TARGET = "Target";
 const KEY_VULNERABILITIES = "Vulnerabilities";

--- a/src/trivyHelper.ts
+++ b/src/trivyHelper.ts
@@ -41,11 +41,12 @@ export interface TrivyResult {
 
 export async function runTrivy(): Promise<TrivyResult> {
     const trivyPath = await getTrivy();
+    const trivyCommand = "image";
 
     const imageName = inputHelper.imageName;
     const trivyOptions: ExecOptions = await getTrivyExecOptions();
     console.log(`Scanning for vulnerabilties in image: ${imageName}`);
-    const trivyToolRunner = new ToolRunner(trivyPath, [imageName], trivyOptions);
+    const trivyToolRunner = new ToolRunner(trivyPath, [trivyCommand, imageName], trivyOptions);
     const timestamp = new Date().toISOString();
     const trivyStatus = await trivyToolRunner.exec();
     utils.addLogsToDebug(getTrivyLogPath());


### PR DESCRIPTION
Trivy [v0.23.0](https://github.com/aquasecurity/trivy/releases/tag/v0.23.0) removed the deprecated root command for `trivy [image-name]`. The old command has been replaced by `trivy image [command options] image_name`.

Fixes #122 