### PR TITLE
Specify Trivy version in workflow file

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -18,6 +18,10 @@ inputs:
     description: 'Github token'
     default: ${{ github.token }}
     required: true
+  trivy-version:
+    description: 'Version of Trivy to run'
+    default: 'latest'
+    required: false
   run-quality-checks:
     description: 'Add additional checks to ensure the image is secure and follows best practices and CIS standards'
     default: 'true'

--- a/src/inputHelper.ts
+++ b/src/inputHelper.ts
@@ -4,6 +4,7 @@ export const imageName = core.getInput("image-name");
 export const githubToken = core.getInput("token");
 export const username = core.getInput("username");
 export const password = core.getInput("password");
+export const trivyVersion = core.getInput("trivy-version");
 export const severityThreshold = core.getInput("severity-threshold");
 export const runQualityChecks = core.getInput("run-quality-checks");
 

--- a/src/trivyHelper.ts
+++ b/src/trivyHelper.ts
@@ -61,7 +61,7 @@ export async function runTrivy(): Promise<TrivyResult> {
 export async function getTrivy(): Promise<string> {
 
     let latestTrivyVersion = inputHelper.trivyVersion;
-    if(trivyVersion == 'latest'){
+    if(latestTrivyVersion == 'latest'){
         latestTrivyVersion = await getLatestTrivyVersion();
     }
     console.log(`Use Trivy version: ${latestTrivyVersion}` );

--- a/src/trivyHelper.ts
+++ b/src/trivyHelper.ts
@@ -11,6 +11,7 @@ import * as fileHelper from './fileHelper';
 import * as inputHelper from './inputHelper';
 import * as utils from './utils';
 import * as allowedlistHandler from './allowedlistHandler';
+import {trivyVersion} from "./inputHelper";
 
 export const TRIVY_EXIT_CODE = 5;
 export const trivyToolName = "trivy";
@@ -43,6 +44,7 @@ export async function runTrivy(): Promise<TrivyResult> {
     const trivyPath = await getTrivy();
 
     const imageName = inputHelper.imageName;
+
     const trivyOptions: ExecOptions = await getTrivyExecOptions();
     console.log(`Scanning for vulnerabilties in image: ${imageName}`);
     const trivyToolRunner = new ToolRunner(trivyPath, [imageName], trivyOptions);
@@ -57,8 +59,11 @@ export async function runTrivy(): Promise<TrivyResult> {
 }
 
 export async function getTrivy(): Promise<string> {
-    const latestTrivyVersion = await getLatestTrivyVersion();
 
+    let latestTrivyVersion = inputHelper.trivyVersion;
+    if(trivyVersion == 'latest'){
+        latestTrivyVersion = await getLatestTrivyVersion();
+    }
     let cachedToolPath = toolCache.find(trivyToolName, latestTrivyVersion);
     if (!cachedToolPath) {
         let trivyDownloadPath;

--- a/src/trivyHelper.ts
+++ b/src/trivyHelper.ts
@@ -64,6 +64,7 @@ export async function getTrivy(): Promise<string> {
     if(trivyVersion == 'latest'){
         latestTrivyVersion = await getLatestTrivyVersion();
     }
+    console.log(`Use Trivy version: ${latestTrivyVersion}` );
     let cachedToolPath = toolCache.find(trivyToolName, latestTrivyVersion);
     if (!cachedToolPath) {
         let trivyDownloadPath;


### PR DESCRIPTION
To enable to use previous version av Trivy when breaking changes occur before container-scan action is updated.
If not set, default is latest version.