### PR TITLE
Update trivyHelper.ts

### DIFF
--- a/src/trivyHelper.ts
+++ b/src/trivyHelper.ts
@@ -14,7 +14,7 @@ import * as allowedlistHandler from './allowedlistHandler';
 
 export const TRIVY_EXIT_CODE = 5;
 export const trivyToolName = "trivy";
-const stableTrivyVersion = "0.22.0";
+const stableTrivyVersion = "0.23.0";
 const trivyLatestReleaseUrl = "https://api.github.com/repos/aquasecurity/trivy/releases/latest";
 const KEY_TARGET = "Target";
 const KEY_VULNERABILITIES = "Vulnerabilities";


### PR DESCRIPTION
Use latest version (0.23.0) of trivy as fallback which removes non-commercial db.