### PR TITLE
added: capability to specify Dockle version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This action can be used to help you add some additional checks to help you secure your Docker Images in your  CI. This would help you attain some confidence in your docker image before pushing them to your container registry or a deployment.
 
-It internally uses `Trivy` and `Dockle` for running certain kinds of scans on these images. 
-- [`Trivy`](https://github.com/aquasecurity/trivy) helps you find the common vulnerabilities within your docker images. 
-- [`Dockle`](https://github.com/goodwithtech/dockle) is a container linter, which helps you identify if you haven't followed 
-  - Certain best practices while building the image 
+It internally uses `Trivy` and `Dockle` for running certain kinds of scans on these images.
+- [`Trivy`](https://github.com/aquasecurity/trivy) helps you find the common vulnerabilities within your docker images.
+- [`Dockle`](https://github.com/goodwithtech/dockle) is a container linter, which helps you identify if you haven't followed
+  - Certain best practices while building the image
   - [CIS Benchmarks](https://www.cisecurity.org/cis-benchmarks/) to secure your docker image
 
 Please checkout [Trivy](https://github.com/aquasecurity/trivy/blob/main/LICENSE) and [Dockle](https://github.com/goodwithtech/dockle/blob/master/LICENSE) licenses.
@@ -44,17 +44,22 @@ Please checkout [Trivy](https://github.com/aquasecurity/trivy/blob/main/LICENSE)
     <td><code>password</code></td>
     <td>(Optional) Password to authenticate to the Docker registry. This is only required when you're trying to pull an image from your private registry</td>
     <td>''</td>
-  </tr>  
+  </tr>
   <tr>
     <td><code>trivy-version</code></td>
     <td>(Optional) Version of Trivy to run, e.g. 0.22.0. The default is to use latest version. </td>
+    <td>''</td>
+  </tr>
+  <tr>
+    <td><code>dockle-version</code></td>
+    <td>(Optional) Version of Dockle to run, e.g. 0.2.4. The default is to use latest version. </td>
     <td>''</td>
   </tr>
 
 </table>
 
 ## Action output
-The action generates an output file consisting of detailed description of all the detected vulnerabilities and best practice violations in JSON format. This file can be accessed by using the output variable `scan-report-path`.  
+The action generates an output file consisting of detailed description of all the detected vulnerabilities and best practice violations in JSON format. This file can be accessed by using the output variable `scan-report-path`.
 Here is a sample scan report:
 ```json
 {
@@ -149,10 +154,10 @@ Install [Scanitizer](https://github.com/apps/scanitizer) (currently in Beta) on 
 
 ## End to end workflow using Azure
 
-The following is an example of not just this action, but how this action could be used along with other  actions to setup a CI. 
+The following is an example of not just this action, but how this action could be used along with other  actions to setup a CI.
 
 Where your CI would:
-- Build a docker image 
+- Build a docker image
 - Scan the docker image for any security vulnerabilities
 - Publish it to your private container registry.
 
@@ -166,25 +171,25 @@ jobs:
     - uses: actions/checkout@master
 
     - run: docker build . -t contoso.azurecr.io/k8sdemo:${{ github.sha }}
-      
+
     - uses: Azure/container-scan@v0
       with:
         image-name: contoso.azurecr.io/k8sdemo:${{ github.sha }}
-    
+
     - uses: Azure/docker-login@v1
       with:
         login-server: contoso.azurecr.io
         username: ${{ secrets.REGISTRY_USERNAME }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
-    
+
     - run: docker push contoso.azurecr.io/k8sdemo:${{ github.sha }}
 ```
 ## End to end workflow using any container repository and workflow environment variables
 
-The following is an example of not just this action, but how this action could be used along with other actions to setup a CI. 
+The following is an example of not just this action, but how this action could be used along with other actions to setup a CI.
 
 Where your CI would:
-- Build a docker image 
+- Build a docker image
 - Scan the docker image for any security vulnerabilities
 - Publish it to your preferred container registry.
 
@@ -200,17 +205,17 @@ jobs:
     - uses: actions/checkout@master
 
     - run: docker build . -t ${{ env.CONTAINER_REGISTRY }}/k8sdemo:${{ github.sha }}
-      
+
     - uses: Azure/container-scan@v0
       with:
         image-name: ${{ env.CONTAINER_REGISTRY }}/k8sdemo:${{ github.sha }}
-    
+
     - uses: Azure/docker-login@v1
       with:
         login-server: ${{ env.CONTAINER_REGISTRY }}
         username: ${{ secrets.REGISTRY_USERNAME }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
-    
+
     - run: docker push ${{ env.CONTAINER_REGISTRY }}/k8sdemo:${{ github.sha }}
 ```
 

--- a/__mocks__/@actions/core.ts
+++ b/__mocks__/@actions/core.ts
@@ -7,7 +7,8 @@ let __mockInputValues = {
     'password': 'password',
     'severit-threshold': 'HIGH',
     'run-quality-checks': 'true',
-    'trivy-version': 'latest'
+    'trivy-version': 'latest',
+    'dockle-version': 'latest'
 };
 
 function __setMockInputValues(mockObject) {

--- a/__tests__/dockleHelper.test.ts
+++ b/__tests__/dockleHelper.test.ts
@@ -4,20 +4,28 @@ jest.mock('os');
 describe('Run Dockle', () => {
     const mockedFs = require('fs');
     const mockedOs = require('os');
-    const mockedToolCache = require('@actions/tool-cache');
-    const mockedFileHelper = require('../src/fileHelper');
-    mockedFileHelper.getContainerScanDirectory = jest.fn().mockImplementation(() =>{
-        return 'test/_temp/containerscan_123';
-    });
-            
-    let mockFile = {
-        'releaseDownloadedPath': JSON.stringify({ tag_name: 'v1.1.1' })
-    };
-    let cachedTools = {
-        'trivy': true,
-        'dockle': true
-    };
-    mockedFs.__setMockFiles(mockFile);
+
+    function setupFileMock() {
+        const mockedFileHelper = require('../src/fileHelper');
+        mockedFileHelper.getContainerScanDirectory = jest.fn().mockImplementation(() => {
+            return 'test/_temp/containerscan_123';
+        });
+
+        return {
+            'releaseDownloadedPath': JSON.stringify({tag_name: 'v1.1.1'})
+        };
+    }
+    mockedFs.__setMockFiles(setupFileMock());
+
+    function toolCache() {
+        const mockedToolCache = require('@actions/tool-cache');
+        let cachedTools = {
+            'trivy': true,
+            'dockle': true
+        };
+        return {mockedToolCache, cachedTools};
+    }
+    let {mockedToolCache, cachedTools} = toolCache();
     mockedToolCache.__setToolCached(cachedTools);
 
     afterAll(() => {
@@ -35,7 +43,7 @@ describe('Run Dockle', () => {
         expect(mockedToolCache.downloadTool).toHaveBeenCalledTimes(1);
     });
 
-    test('Dockle binaries are not present in the cache', async () => {        
+    test('Dockle binaries are not present in the cache', async () => {
         cachedTools['dockle'] = false;
         mockedToolCache.__setToolCached(cachedTools);
 
@@ -45,5 +53,29 @@ describe('Run Dockle', () => {
         expect(mockedOs.type).toHaveBeenCalledTimes(1);
         expect(mockedToolCache.find).toHaveReturnedWith(undefined);
         expect(mockedToolCache.downloadTool).toHaveBeenCalledTimes(2);
+    });
+
+    test('Dockle binaries are not present in the cache and not use latest version', async () => {
+        jest.resetModules();
+        const mockedFs = require('fs');
+        const mockedOs = require('os');
+        mockedFs.__setMockFiles(setupFileMock());
+        let {mockedToolCache, cachedTools} = toolCache();
+        cachedTools['dockle'] = false;
+        mockedToolCache.__setToolCached(cachedTools);
+        jest.mock('../src/inputHelper', () => {
+            const inputHelper = jest.requireActual('../src/inputHelper');
+            return {
+                __esModule: true,
+                ...inputHelper,
+                dockleVersion: '0.4.5',
+            };
+        });
+
+        const runner = require('../src/dockleHelper');
+        await expect(runner.runDockle()).resolves.toBe(0);
+        expect(mockedOs.type).toHaveBeenCalledTimes(1);
+        expect(mockedToolCache.find).toHaveReturnedWith(undefined);
+        expect(mockedToolCache.downloadTool).toHaveBeenCalledTimes(1);
     });
 });

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,10 @@ inputs:
     description: 'Version of Trivy to run'
     default: 'latest'
     required: false
+  dockle-version:
+    description: 'Version of Dockle to run'
+    default: 'latest'
+    required: false
   run-quality-checks:
     description: 'Add additional checks to ensure the image is secure and follows best practices and CIS standards'
     default: 'true'

--- a/lib/dockleHelper.js
+++ b/lib/dockleHelper.js
@@ -63,11 +63,15 @@ function runDockle() {
 exports.runDockle = runDockle;
 function getDockle() {
     return __awaiter(this, void 0, void 0, function* () {
-        const latestDockleVersion = yield getLatestDockleVersion();
-        let cachedToolPath = toolCache.find(exports.dockleToolName, latestDockleVersion);
+        let version = inputHelper.dockleVersion;
+        if (version == 'latest') {
+            version = yield getLatestDockleVersion();
+        }
+        core.debug(util.format('Use Dockle version: %s', version));
+        let cachedToolPath = toolCache.find(exports.dockleToolName, version);
         if (!cachedToolPath) {
             let dockleDownloadPath;
-            const dockleDownloadUrl = getDockleDownloadUrl(latestDockleVersion);
+            const dockleDownloadUrl = getDockleDownloadUrl(version);
             const dockleDownloadDir = `${process.env['GITHUB_WORKSPACE']}/_temp/tools/dockle`;
             core.debug(util.format("Could not find dockle in cache, downloading from %s", dockleDownloadUrl));
             try {
@@ -77,7 +81,7 @@ function getDockle() {
                 throw new Error(util.format("Failed to download dockle from %s", dockleDownloadUrl));
             }
             const untarredDocklePath = yield toolCache.extractTar(dockleDownloadPath);
-            cachedToolPath = yield toolCache.cacheDir(untarredDocklePath, exports.dockleToolName, latestDockleVersion);
+            cachedToolPath = yield toolCache.cacheDir(untarredDocklePath, exports.dockleToolName, version);
         }
         const dockleToolPath = cachedToolPath + "/" + exports.dockleToolName;
         fs.chmodSync(dockleToolPath, "777");

--- a/lib/inputHelper.js
+++ b/lib/inputHelper.js
@@ -13,6 +13,7 @@ exports.githubToken = core.getInput("token");
 exports.username = core.getInput("username");
 exports.password = core.getInput("password");
 exports.trivyVersion = core.getInput("trivy-version");
+exports.dockleVersion = core.getInput("dockle-version");
 exports.severityThreshold = core.getInput("severity-threshold");
 exports.runQualityChecks = core.getInput("run-quality-checks");
 function isRunQualityChecksEnabled() {

--- a/src/dockleHelper.ts
+++ b/src/dockleHelper.ts
@@ -46,11 +46,15 @@ export async function runDockle(): Promise<number> {
 }
 
 export async function getDockle(): Promise<string> {
-    const latestDockleVersion = await getLatestDockleVersion();
-    let cachedToolPath = toolCache.find(dockleToolName, latestDockleVersion);
+    let version = inputHelper.dockleVersion;
+    if(version == 'latest'){
+        version = await getLatestDockleVersion();
+    }
+    core.debug(util.format('Use Dockle version: %s', version));
+    let cachedToolPath = toolCache.find(dockleToolName, version);
     if (!cachedToolPath) {
         let dockleDownloadPath;
-        const dockleDownloadUrl = getDockleDownloadUrl(latestDockleVersion);
+        const dockleDownloadUrl = getDockleDownloadUrl(version);
         const dockleDownloadDir = `${process.env['GITHUB_WORKSPACE']}/_temp/tools/dockle`;
         core.debug(util.format("Could not find dockle in cache, downloading from %s", dockleDownloadUrl));
 
@@ -61,7 +65,7 @@ export async function getDockle(): Promise<string> {
         }
 
         const untarredDocklePath = await toolCache.extractTar(dockleDownloadPath);
-        cachedToolPath = await toolCache.cacheDir(untarredDocklePath, dockleToolName, latestDockleVersion);
+        cachedToolPath = await toolCache.cacheDir(untarredDocklePath, dockleToolName, version);
     }
 
     const dockleToolPath = cachedToolPath + "/" + dockleToolName;

--- a/src/inputHelper.ts
+++ b/src/inputHelper.ts
@@ -5,6 +5,7 @@ export const githubToken = core.getInput("token");
 export const username = core.getInput("username");
 export const password = core.getInput("password");
 export const trivyVersion = core.getInput("trivy-version");
+export const dockleVersion = core.getInput("dockle-version");
 export const severityThreshold = core.getInput("severity-threshold");
 export const runQualityChecks = core.getInput("run-quality-checks");
 


### PR DESCRIPTION
Updated github action to include a new optional argument called
`dockle-version`, which allows you to specify the version of Dockle
that you want to use for the scan. If the value is not provided, it will
default to `latest`.

Added new test, and updated the `lib` folder to include the changes.

Signed-off-by: Scott Westover <scottwestover2006@gmail.com>